### PR TITLE
Overwritable routes file

### DIFF
--- a/src/NewsCRUDServiceProvider.php
+++ b/src/NewsCRUDServiceProvider.php
@@ -17,7 +17,7 @@ class NewsCRUDServiceProvider extends ServiceProvider
     /**
      * Where the route file lives, both inside the package and in the app (if overwritten).
      *
-     * @var bool
+     * @var string
      */
     public $routeFilePath = '/routes/backpack/newscrud.php';
 

--- a/src/NewsCRUDServiceProvider.php
+++ b/src/NewsCRUDServiceProvider.php
@@ -15,6 +15,13 @@ class NewsCRUDServiceProvider extends ServiceProvider
     protected $defer = false;
 
     /**
+     * Where the route file lives, both inside the package and in the app (if overwritten).
+     *
+     * @var bool
+     */
+    public $routeFilePath = '/routes/backpack/newscrud.php';
+
+    /**
      * Perform post-registration booting of services.
      *
      * @return void
@@ -23,23 +30,6 @@ class NewsCRUDServiceProvider extends ServiceProvider
     {
         // publish migrations
         $this->publishes([__DIR__.'/database/migrations' => database_path('migrations')], 'migrations');
-    }
-
-    /**
-     * Define the routes for the application.
-     *
-     * @param  \Illuminate\Routing\Router  $router
-     * @return void
-     */
-    public function setupRoutes(Router $router)
-    {
-        $router->group(['namespace' => 'Backpack\NewsCRUD\app\Http\Controllers'], function ($router) {
-            \Route::group(['prefix' => config('backpack.base.route_prefix', 'admin'), 'middleware' => ['web', 'admin'], 'namespace' => 'Admin'], function () {
-                \CRUD::resource('article', 'ArticleCrudController');
-                \CRUD::resource('category', 'CategoryCrudController');
-                \CRUD::resource('tag', 'TagCrudController');
-            });
-        });
     }
 
     /**
@@ -52,8 +42,26 @@ class NewsCRUDServiceProvider extends ServiceProvider
         // register its dependencies
         $this->app->register(\Cviebrock\EloquentSluggable\ServiceProvider::class);
 
-        if(!config('backpack.base.skip_all_backpack_routes',false)){
-            $this->setupRoutes($this->app->router);            
+        // setup the routes
+        $this->setupRoutes($this->app->router);
+    }
+
+    /**
+     * Define the routes for the application.
+     *
+     * @param  \Illuminate\Routing\Router  $router
+     * @return void
+     */
+    public function setupRoutes(Router $router)
+    {
+        // by default, use the routes file provided in vendor
+        $routeFilePathInUse = __DIR__.$this->routeFilePath;
+
+        // but if there's a file with the same name in routes/backpack, use that one
+        if (file_exists(base_path().$this->routeFilePath)) {
+            $routeFilePathInUse = base_path().$this->routeFilePath;
         }
+
+        $this->loadRoutesFrom($routeFilePathInUse);
     }
 }

--- a/src/routes/backpack/newscrud.php
+++ b/src/routes/backpack/newscrud.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Backpack\NewsCRUD Routes
+|--------------------------------------------------------------------------
+|
+| This file is where you may define or change all of the routes that are
+| handled by the Backpack\NewsCRUD package.
+|
+*/
+
+Route::group([
+				'namespace' => 'Backpack\NewsCRUD\app\Http\Controllers\Admin',
+				'prefix' => config('backpack.base.route_prefix', 'admin'),
+				'middleware' => ['web', 'admin'],
+			], function () {
+    CRUD::resource('article', 'ArticleCrudController');
+    CRUD::resource('category', 'CategoryCrudController');
+    CRUD::resource('tag', 'TagCrudController');
+});

--- a/src/routes/backpack/newscrud.php
+++ b/src/routes/backpack/newscrud.php
@@ -11,11 +11,11 @@
 */
 
 Route::group([
-				'namespace' => 'Backpack\NewsCRUD\app\Http\Controllers\Admin',
-				'prefix' => config('backpack.base.route_prefix', 'admin'),
-				'middleware' => ['web', 'admin'],
-			], function () {
-    CRUD::resource('article', 'ArticleCrudController');
-    CRUD::resource('category', 'CategoryCrudController');
-    CRUD::resource('tag', 'TagCrudController');
-});
+                'namespace' => 'Backpack\NewsCRUD\app\Http\Controllers\Admin',
+                'prefix' => config('backpack.base.route_prefix', 'admin'),
+                'middleware' => ['web', 'admin'],
+            ], function () {
+                CRUD::resource('article', 'ArticleCrudController');
+                CRUD::resource('category', 'CategoryCrudController');
+                CRUD::resource('tag', 'TagCrudController');
+            });

--- a/src/routes/backpack/newscrud.php
+++ b/src/routes/backpack/newscrud.php
@@ -5,7 +5,7 @@
 | Backpack\NewsCRUD Routes
 |--------------------------------------------------------------------------
 |
-| This file is where you may define or change all of the routes that are
+| This file is where you may define all of the routes that are
 | handled by the Backpack\NewsCRUD package.
 |
 */


### PR DESCRIPTION
This is the result of what we've been talking about here: https://github.com/Laravel-Backpack/Base/issues/131 and @eduardoarandah 's PR here https://github.com/Laravel-Backpack/NewsCRUD/pull/23

It separates the needed routes into a routes file, that can be easily overwritten by just placing a file with the same name in your routes folder. **If we merge this, overwriting the NewsCRUD routes will be as simple as creating the ```routes/backpack/newscrud.php``` file.** Similar PRs will follow for all packages, of course.

Questions:
1) For the folder name, should we be using ```routes/backpack/``` or ```routes/vendor/backpack```? The former would follow the same pattern as config files. The ladder the same pattern as views... Either way, we don't enforce a strict pattern. This does not do my OCD any good...

2) Do you guys see any possible issues? A better solution? Possible breaking changes? Anything that would prevent us from merging this as a non-breaking-change?

Cheers!
