### PR TITLE
Support for Backpack 4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 -------------
 
+## 4.0.0 - 2020-05-06
+
+### Added
+- support for Backpack 4.1
+- column anchors to CategoryCRUD;
+- filters to ArticleCRUD;
+- relationship columns to ArticleCRUD, along with inlineCreate for both Category and Tags;
+
+### Removed
+- support for Backpack 4.0
+
+
+-------------
+
 ## 3.0.3 - 2020-03-05
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "backpack/crud": "^4.0.99|^4.1.0",
+        "backpack/crud": "^4.1.0",
         "cviebrock/eloquent-sluggable": "^7.0||^6.0||4.8"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "backpack/crud": "^4.0.0",
+        "backpack/crud": "^4.0.99|^4.1.0",
         "cviebrock/eloquent-sluggable": "^7.0||^6.0||4.8"
     },
     "require-dev": {

--- a/src/app/Http/Controllers/Admin/ArticleCrudController.php
+++ b/src/app/Http/Controllers/Admin/ArticleCrudController.php
@@ -76,7 +76,7 @@ class ArticleCrudController extends CrudController
             ], function () {
                 return \Backpack\NewsCRUD\app\Models\Tag::all()->keyBy('id')->pluck('name', 'id')->toArray();
             }, function ($values) { // if the filter is active
-                $this->crud->query = $this->crud->query->whereHas('tags', function($q) use ($values) {
+                $this->crud->query = $this->crud->query->whereHas('tags', function ($q) use ($values) {
                     foreach (json_decode($values) as $key => $value) {
                         if ($key == 0) {
                             $q->where('tags.id', $value);

--- a/src/app/Http/Controllers/Admin/ArticleCrudController.php
+++ b/src/app/Http/Controllers/Admin/ArticleCrudController.php
@@ -15,6 +15,7 @@ class ArticleCrudController extends CrudController
     use \Backpack\CRUD\app\Http\Controllers\Operations\DeleteOperation;
     use \Backpack\CRUD\app\Http\Controllers\Operations\BulkDeleteOperation;
     use \Backpack\CRUD\app\Http\Controllers\Operations\ShowOperation;
+    use \Backpack\CRUD\app\Http\Controllers\Operations\FetchOperation;
 
     public function setup()
     {
@@ -23,7 +24,7 @@ class ArticleCrudController extends CrudController
         | BASIC CRUD INFORMATION
         |--------------------------------------------------------------------------
         */
-        $this->crud->setModel("Backpack\NewsCRUD\app\Models\Article");
+        $this->crud->setModel(\Backpack\NewsCRUD\app\Models\Article::class);
         $this->crud->setRoute(config('backpack.base.route_prefix', 'admin').'/article');
         $this->crud->setEntityNameStrings('article', 'articles');
 
@@ -127,18 +128,22 @@ class ArticleCrudController extends CrudController
             ]);
             $this->crud->addField([
                 'label' => 'Category',
-                'type' => 'select2',
+                'type' => 'relationship',
                 'name' => 'category_id',
                 'entity' => 'category',
                 'attribute' => 'name',
+                'inline_create' => true,
+                'ajax' => true,
             ]);
             $this->crud->addField([
                 'label' => 'Tags',
-                'type' => 'select2_multiple',
+                'type' => 'relationship',
                 'name' => 'tags', // the method that defines the relationship in your Model
                 'entity' => 'tags', // the method that defines the relationship in your Model
                 'attribute' => 'name', // foreign key attribute that is shown to user
                 'pivot' => true, // on create&update, do you need to add/delete pivot table entries?
+                'inline_create' => ['entity' => 'tag'],
+                'ajax' => true,
             ]);
             $this->crud->addField([
                 'name' => 'status',
@@ -151,5 +156,23 @@ class ArticleCrudController extends CrudController
                 'type' => 'checkbox',
             ]);
         });
+    }
+
+    /**
+     * Respond to AJAX calls from the select2 with entries from the Category model.
+     * @return JSON
+     */
+    public function fetchCategory()
+    {
+        return $this->fetch(\Backpack\NewsCRUD\app\Models\Category::class);
+    }
+
+    /**
+     * Respond to AJAX calls from the select2 with entries from the Tag model.
+     * @return JSON
+     */
+    public function fetchTags()
+    {
+        return $this->fetch(\Backpack\NewsCRUD\app\Models\Tag::class);
     }
 }

--- a/src/app/Http/Controllers/Admin/CategoryCrudController.php
+++ b/src/app/Http/Controllers/Admin/CategoryCrudController.php
@@ -14,6 +14,7 @@ class CategoryCrudController extends CrudController
     use \Backpack\CRUD\app\Http\Controllers\Operations\DeleteOperation;
     use \Backpack\CRUD\app\Http\Controllers\Operations\ReorderOperation;
     use \Backpack\CRUD\app\Http\Controllers\Operations\ShowOperation;
+    use \Backpack\CRUD\app\Http\Controllers\Operations\InlineCreateOperation;
 
     public function setup()
     {

--- a/src/app/Http/Controllers/Admin/CategoryCrudController.php
+++ b/src/app/Http/Controllers/Admin/CategoryCrudController.php
@@ -33,11 +33,24 @@ class CategoryCrudController extends CrudController
             'entity' => 'parent',
             'attribute' => 'name',
         ]);
+        CRUD::addColumn([   // select_multiple: n-n relationship (with pivot table)
+            'label'     => 'Articles', // Table column heading
+            'type'      => 'relationship_count',
+            'name'      => 'articles', // the method that defines the relationship in your Model
+            'wrapper'   => [
+                'href' => function ($crud, $column, $entry, $related_key) {
+                    return backpack_url('article?category_id='.$entry->getKey());
+                },
+            ],
+        ]);
     }
 
     protected function setupShowOperation()
     {
-        return $this->setupListOperation();
+        $this->setupListOperation();
+
+        CRUD::addColumn('created_at');
+        CRUD::addColumn('updated_at');
     }
 
     protected function setupCreateOperation()

--- a/src/app/Http/Controllers/Admin/TagCrudController.php
+++ b/src/app/Http/Controllers/Admin/TagCrudController.php
@@ -11,6 +11,7 @@ class TagCrudController extends CrudController
     use \Backpack\CRUD\app\Http\Controllers\Operations\CreateOperation;
     use \Backpack\CRUD\app\Http\Controllers\Operations\UpdateOperation;
     use \Backpack\CRUD\app\Http\Controllers\Operations\DeleteOperation;
+    use \Backpack\CRUD\app\Http\Controllers\Operations\InlineCreateOperation;
 
     public function setup()
     {


### PR DESCRIPTION
Also:
- added column anchors to CategoryCRUD;
- added filters to ArticleCRUD;
- added ```relationship``` columns to ArticleCRUD, along with inlineCreate for both Category and Tags;

The syntax used inside the CRUDs is still inconsistent, but that's on purpose - it helps us highlight ways to do stuff in Backpack. But more importantly, it helps us _test_ those ways.