### PR TITLE
Author and social media

### DIFF
--- a/src/app/Http/Controllers/Admin/ArticleCrudController.php
+++ b/src/app/Http/Controllers/Admin/ArticleCrudController.php
@@ -34,7 +34,13 @@ class ArticleCrudController extends CrudController
         |--------------------------------------------------------------------------
         */
         $this->crud->operation('list', function () {
-            $this->crud->addColumn('title');
+	    $this->crud->addColumn('title');
+	    $this->crud->addColumn('author');
+            $this->crud->addColumn([
+                'name' => 'social_media',
+                'label' => 'Social Media',
+                'type' => 'text',
+            ]);
             $this->crud->addColumn([
                 'name' => 'date',
                 'label' => 'Date',
@@ -102,6 +108,19 @@ class ArticleCrudController extends CrudController
                 'label' => 'Title',
                 'type' => 'text',
                 'placeholder' => 'Your title here',
+	    ]);
+	    $this->crud->addField([
+                'name' => 'author',
+                'label' => 'Author',
+                'type' => 'text',
+                'placeholder' => 'Written by...',
+            ]);
+            $this->crud->addField([
+                'name' => 'social_media',
+                'label' => 'Social Media',
+                'type' => 'text',
+                'placeholder' => 'Let your readers know where you hang',
+                'hint' => 'Let your readers know where you hang.',
             ]);
             $this->crud->addField([
                 'name' => 'slug',

--- a/src/app/Http/Requests/ArticleRequest.php
+++ b/src/app/Http/Requests/ArticleRequest.php
@@ -23,8 +23,8 @@ class ArticleRequest extends \Backpack\CRUD\app\Http\Requests\CrudRequest
     public function rules()
     {
         return [
-	    'title' => 'required|min:2|max:255',
-	    'author' => 'required|min:2|max:255',
+	        'title' => 'required|min:2|max:255',
+	        'author' => 'required|min:2|max:255',
             'slug' => 'unique:articles,slug,'.\Request::get('id'),
             'content' => 'required|min:2',
             'date' => 'required|date',

--- a/src/app/Http/Requests/ArticleRequest.php
+++ b/src/app/Http/Requests/ArticleRequest.php
@@ -23,7 +23,8 @@ class ArticleRequest extends \Backpack\CRUD\app\Http\Requests\CrudRequest
     public function rules()
     {
         return [
-            'title' => 'required|min:2|max:255',
+	    'title' => 'required|min:2|max:255',
+	    'author' => 'required|min:2|max:255',
             'slug' => 'unique:articles,slug,'.\Request::get('id'),
             'content' => 'required|min:2',
             'date' => 'required|date',

--- a/src/app/Models/Article.php
+++ b/src/app/Models/Article.php
@@ -22,7 +22,7 @@ class Article extends Model
     protected $primaryKey = 'id';
     public $timestamps = true;
     // protected $guarded = ['id'];
-    protected $fillable = ['slug', 'title', 'content', 'image', 'status', 'category_id', 'featured', 'date'];
+    protected $fillable = ['slug', 'title', 'author', 'social_media', 'content', 'image', 'status', 'category_id', 'featured', 'date'];
     // protected $hidden = [];
     // protected $dates = [];
     protected $casts = [

--- a/src/database/migrations/2015_08_04_130520_create_articles_table.php
+++ b/src/database/migrations/2015_08_04_130520_create_articles_table.php
@@ -15,8 +15,8 @@ class CreateArticlesTable extends Migration
         Schema::create('articles', function (Blueprint $table) {
             $table->increments('id');
             $table->integer('category_id')->unsigned();
-	    $table->string('title');
-	    $table->string('author');
+	        $table->string('title');
+	        $table->string('author');
             $table->string('social_media')->nullable();
             $table->string('slug')->default('');
             $table->text('content');

--- a/src/database/migrations/2015_08_04_130520_create_articles_table.php
+++ b/src/database/migrations/2015_08_04_130520_create_articles_table.php
@@ -15,7 +15,9 @@ class CreateArticlesTable extends Migration
         Schema::create('articles', function (Blueprint $table) {
             $table->increments('id');
             $table->integer('category_id')->unsigned();
-            $table->string('title');
+	    $table->string('title');
+	    $table->string('author');
+            $table->string('social_media')->nullable();
             $table->string('slug')->default('');
             $table->text('content');
             $table->string('image')->nullable();


### PR DESCRIPTION
#### References Issues/PRs
None
#### What does this implement/fix? Explain your changes.
I added the ability for the NewsCRUD have an Author in the database and Social Media URL which could be implemented in the front-end for example:
```html
<p><a href="https://{{ $article->socialmedia }}">{{ $article->author }}</a><p>
```
#### Any other comments?
Social Media is optional in the Admin panel. I made changes to the Migration, Model, Request, and Controller files. 