### PR TITLE
PHP 8 - Added return type to sluggable(): array

### DIFF
--- a/src/app/Models/Article.php
+++ b/src/app/Models/Article.php
@@ -35,7 +35,7 @@ class Article extends Model
      *
      * @return array
      */
-    public function sluggable()
+    public function sluggable(): array
     {
         return [
             'slug' => [
@@ -75,8 +75,8 @@ class Article extends Model
     public function scopePublished($query)
     {
         return $query->where('status', 'PUBLISHED')
-                    ->where('date', '<=', date('Y-m-d'))
-                    ->orderBy('date', 'DESC');
+            ->where('date', '<=', date('Y-m-d'))
+            ->orderBy('date', 'DESC');
     }
 
     /*

--- a/src/app/Models/Category.php
+++ b/src/app/Models/Category.php
@@ -31,7 +31,7 @@ class Category extends Model
      *
      * @return array
      */
-    public function sluggable()
+    public function sluggable(): array
     {
         return [
             'slug' => [
@@ -76,8 +76,8 @@ class Category extends Model
     public function scopeFirstLevelItems($query)
     {
         return $query->where('depth', '1')
-                    ->orWhere('depth', null)
-                    ->orderBy('lft', 'ASC');
+            ->orWhere('depth', null)
+            ->orderBy('lft', 'ASC');
     }
 
     /*

--- a/src/app/Models/Tag.php
+++ b/src/app/Models/Tag.php
@@ -31,7 +31,7 @@ class Tag extends Model
      *
      * @return array
      */
-    public function sluggable()
+    public function sluggable(): array
     {
         return [
             'slug' => [


### PR DESCRIPTION
original `sluggable()` function now has a return type of array
so on laravel 8 + PHP 8 it shows an error

by adding `:array ` the problem is solved 