### PR TITLE
Add nullable excerpt to article

### DIFF
--- a/src/app/Http/Controllers/Admin/ArticleCrudController.php
+++ b/src/app/Http/Controllers/Admin/ArticleCrudController.php
@@ -123,6 +123,15 @@ class ArticleCrudController extends CrudController
                 'placeholder' => 'Your textarea text here',
             ]);
             $this->crud->addField([
+                'name' => 'excerpt',
+                'label' => 'Excerpt',
+                'type' => 'textarea',
+                'attributes' => [
+                    'maxlength' => 150,
+                ],
+                'placeholder' => 'The excerpt here',
+            ]);
+            $this->crud->addField([
                 'name' => 'image',
                 'label' => 'Image',
                 'type' => 'browse',

--- a/src/app/Http/Requests/ArticleRequest.php
+++ b/src/app/Http/Requests/ArticleRequest.php
@@ -26,6 +26,7 @@ class ArticleRequest extends \Backpack\CRUD\app\Http\Requests\CrudRequest
             'title' => 'required|min:2|max:255',
             'slug' => 'unique:articles,slug,'.\Request::get('id'),
             'content' => 'required|min:2',
+            'excerpt' => 'required|string|max:150',
             'date' => 'required|date',
             'status' => 'required',
             'category_id' => 'required',

--- a/src/app/Models/Article.php
+++ b/src/app/Models/Article.php
@@ -22,7 +22,7 @@ class Article extends Model
     protected $primaryKey = 'id';
     public $timestamps = true;
     // protected $guarded = ['id'];
-    protected $fillable = ['slug', 'title', 'content', 'image', 'status', 'category_id', 'featured', 'date'];
+    protected $fillable = ['slug', 'title', 'content', 'excerpt', 'image', 'status', 'category_id', 'featured', 'date'];
     // protected $hidden = [];
     // protected $dates = [];
     protected $casts = [

--- a/src/database/migrations/2015_08_04_130520_create_articles_table.php
+++ b/src/database/migrations/2015_08_04_130520_create_articles_table.php
@@ -18,6 +18,7 @@ class CreateArticlesTable extends Migration
             $table->string('title');
             $table->string('slug')->default('');
             $table->text('content');
+            $table->text('excerpt')->nullable();
             $table->string('image')->nullable();
             $table->enum('status', ['PUBLISHED', 'DRAFT'])->default('PUBLISHED');
             $table->date('date');


### PR DESCRIPTION
# Add Excerpt to Article
This adds a nullable excerpt attribute to the Article model.

When displaying a list of articles or information about an article like in meta description, it helps to use only the except vs extracting and trimming the content. The ArticleRequest rules method ensures the except is within a size limit (which can be changed).

