### PR TITLE
Fix article status on SQLite databases

### DIFF
--- a/src/app/Http/Controllers/Admin/ArticleCrudController.php
+++ b/src/app/Http/Controllers/Admin/ArticleCrudController.php
@@ -150,6 +150,7 @@ class ArticleCrudController extends CrudController
                 'name' => 'status',
                 'label' => 'Status',
                 'type' => 'enum',
+                'options' => ['PUBLISHED', 'DRAFT'], // only required for sqlite databases
             ]);
             $this->crud->addField([
                 'name' => 'featured',

--- a/src/app/Http/Controllers/Admin/ArticleCrudController.php
+++ b/src/app/Http/Controllers/Admin/ArticleCrudController.php
@@ -149,8 +149,8 @@ class ArticleCrudController extends CrudController
             $this->crud->addField([
                 'name' => 'status',
                 'label' => 'Status',
-                'type' => 'enum',
-                'options' => ['PUBLISHED', 'DRAFT'], // only required for sqlite databases
+                'type' => 'select_from_array',
+                'options' => ['PUBLISHED', 'DRAFT'],
             ]);
             $this->crud->addField([
                 'name' => 'featured',


### PR DESCRIPTION
This allows the NewsCRUD to work on sqlite databases.
This depends on https://github.com/Laravel-Backpack/CRUD/pull/3788.