### PR TITLE
add eloquent sluggable support for L10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,12 @@
     "require": {
         "backpack/crud": "^5.0",
         "backpack/pro": "^1.0",
-        "cviebrock/eloquent-sluggable": "^9.0||^8.0||^7.0||^6.0||4.8"
+        "cviebrock/eloquent-sluggable": "^10.0||^9.0||^8.0||^7.0||^6.0||4.8"
     },
     "require-dev": {
         "phpunit/phpunit" : "^9.0||^7.0",
         "scrutinizer/ocular": "~1.1",
-        "squizlabs/php_codesniffer": "~2.3 || ~3.0"
+        "squizlabs/php_codesniffer": "~2.3||~3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
add `cviebrock/eloquent-sluggable` v10 to support Laravel 10.