### PR TITLE
only support Backpack v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Quality Score][ico-code-quality]][link-code-quality]
 [![Total Downloads][ico-downloads]][link-downloads]
 
-An admin panel for news articles on Laravel 5-9, using [Backpack\CRUD](https://github.com/Laravel-Backpack/crud). Write articles, with categories and tags.
+An admin panel for news articles on Laravel 10, using [Backpack\CRUD](https://github.com/Laravel-Backpack/crud). Write articles, with categories and tags.
 
 
 > ### Security updates and breaking changes

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "backpack/crud": "^5.0",
-        "backpack/pro": "^1.0",
-        "cviebrock/eloquent-sluggable": "^10.0||^9.0||^8.0||^7.0||^6.0||4.8"
+        "backpack/crud": "^6.0",
+        "backpack/pro": "^2.0",
+        "cviebrock/eloquent-sluggable": "^10.0"
     },
     "require-dev": {
         "phpunit/phpunit" : "^9.0||^7.0",


### PR DESCRIPTION
Tada. Backpack v6 works with this out of the box. And since v6 only supports Laravel 10, we can drop support for old Sluggable versions too.